### PR TITLE
flexible joint state message - follow up

### DIFF
--- a/design_drafts/flexible_joint_states_msg.md
+++ b/design_drafts/flexible_joint_states_msg.md
@@ -1,9 +1,12 @@
-# Motivation
+# Flexible Joint State Messages
 
-Throughout `ros_control`, only the three common fields are used for each joint and actuator. 
-These are position, velocity and effort. This is also reflected in [`sensor_msgs/JointState`](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/JointState.html), cementing this setup in place.
-This design is proposing to break with this practice and provide a message that can accomodate reported readings for an arbitrary set of joints and joint interfaces.
-The proposed setup should both allow for reporting values for user-defined interfaces as well as making reporting position, velocity and effort optional. 
+## Motivation
+
+Throughout `ros_control`, only the three common fields are used for each joint and actuator.
+These are position, velocity and effort.
+This is also reflected in [`sensor_msgs/JointState`](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/JointState.html), cementing this setup in place.
+This design is proposing to break with this practice and provide a message that can accommodate reported readings for an arbitrary set of joints and joint interfaces.
+The proposed setup should both allow for reporting values for user-defined interfaces as well as making reporting position, velocity and effort optional.
 The rationale behind the latter is that it is currently left entirely to user-policy whether e.g. velocity and effort should be filled with zeroes when only position is reported and how to tell if this is the case.
 A set of mixed-type joints would e.g. have zeroes or NaNs for one joint in the position vector and effort but only fill velocity with proper values.
 
@@ -12,7 +15,7 @@ Further in this text `value-type` is used to refer to a type of value reported i
 Assumptions in the current setup:
 * the values in `position`, `velocity` and `effort` are aligned with the joint names in `name`.
 
-# Goal
+## Goal
 
 To define a new message that
 1. allows to report additional values on top of position, velocity and effort,
@@ -20,10 +23,9 @@ To define a new message that
 3. does not enforce defining values for every joint in every value-type,
 4. provides a realtime-friendly way of use (some assumptions are fair to use),
 
-# Design
+## Design
 
 The main advantage of `sensor_msgs/JointState` is that it provides a fairly flat structure which, given some assumptions are met, it is easy to process in realtime-safe code.
-
 
 ```
 Header header
@@ -34,7 +36,7 @@ float64[] velocity
 float64[] effort
 ```
 
-## First proposal
+### First proposal
 
 ```
 Header header
@@ -51,10 +53,13 @@ Assumptions:
 * the values in `value` are aligned with the joint names in `name`.
 
 Possible improvements:
-* Turn `interface_name` into an enum and define it in a message. This would be problematic as we are - yet again - baking names into the system. Extending the list would result in MD5 changes in this message too.
-* Support a set of helper functions in the form of header-only files along with `control_msgs`. Nothing says that a messages package cannot ship some util code too.
+* Turn `interface_name` into an enum and define it in a message.
+This would be problematic as we are - yet again - baking names into the system.
+Extending the list would result in MD5 changes in this message too.
+* Support a set of helper functions in the form of header-only files along with `control_msgs`.
+Nothing says that a messages package cannot ship some util code, too.
 
-## Second proposal
+### Second proposal
 
 ```
 Header header

--- a/design_drafts/flexible_joint_states_msg.md
+++ b/design_drafts/flexible_joint_states_msg.md
@@ -19,15 +19,28 @@ One example could be a suction gripper, which may report only the applied pressu
 
 ## Goal
 
-With the given motivation, We therefore propose to introduce a flexible way of providing custom values in the joint state message to address the given problems mentioned above.
+With the given motivation, we therefore propose to introduce a flexible way of providing custom values in the joint state message to address the given problems mentioned above.
 
 Further in this text `value-identifier` is used to refer to a type of value reported in joint states, e.g. `position`, `velocity` and `effort`.
 
-To define a new message that
+The requirements for a flexible joint state message are fulfilled, if it
 1. does not enforce defining position, velocity and effort for every joint,
 1. supports different hardware interface to report additional values on top of position, velocity and effort,
 3. does not enforce defining values for every joint in every value-identifier,
 4. provides a realtime-friendly way of use (some assumptions are fair to use),
+
+If the requirements are all fulfilled, the flexible joint state message can replace the currently used `JointStateHandles`.
+One can consider the flexible joint state message to represent not only a ROS message, which being used for communication.
+The same message instance can be used internal to ROS control as a storage instance which is used to propagate the robot's state to the loaded controllers.
+That is, the hardware interface can fill the joint state message with all information the underlying hardware reports.
+This would traditionally be joint states such as `position` and `velocity`, but also provides the flexibility to be extended by non-classical hardware interfaces such as grippers or custom sensors/actuators.
+The joint state message would then be passed to each individual controller to read the appropriate information about of the message and perform their calculation.
+The result of each controller can be similarly be stored in the same instance of the joint state message which will be eventually passed back to the hardware interface.
+The hardware interface then can extract the result of the controller's computation from the message and apply their values to the hardware.
+That not only allows to easily combine multiple controllers, but also a dynamic composition of the hardware interface to contain multiple interfaces to various hardware components such as robots, external grippers.
+This composition can become extremely handy when dealing with external components to a robot, such as a gripper or the previously mentioned mobile manipulator, where the base platform is not necessarily coupled with the robotic arm.
+
+For more details on how the flexible joint state message can be used to create complex controller schemes, please refer to [controller execution management](controller_execution_management.md).
 
 ## Design
 

--- a/design_drafts/flexible_joint_states_msg.md
+++ b/design_drafts/flexible_joint_states_msg.md
@@ -9,7 +9,7 @@ This design is proposing to break with this practice and provide a message that 
 The proposed setup should both allow for reporting values for user-defined interfaces as well as making reporting position, velocity and effort optional.
 The rationale behind the latter is that it is currently left entirely to user-policy whether e.g. velocity and effort should be filled with zeroes when only position is reported and how to tell if this is the case.
 The flexible joint state message shall encompass a complex  hardware setup, covering a mix of different actuators and sensors.
-A set of mixed-type joints would e.g. be a mobile actuator.
+A set of mixed-type joints would e.g. be a mobile manipulator.
 One could think of a diff drive controller only providing velocity values, whereas the manipulator provides the full joint state (`position`, `velocity`, `effort`) for its joints.
 In the example given, it would be possible to provide pre-defined fields in a statically defined joint state message, however this brings two problems with it:
 1. How can the user indicate that a certain field (e.g. `effort`) is not provided for the joint?

--- a/design_drafts/flexible_joint_states_msg.md
+++ b/design_drafts/flexible_joint_states_msg.md
@@ -5,27 +5,34 @@
 Throughout `ros_control`, only the three common fields are used for each joint and actuator.
 These are position, velocity and effort.
 This is also reflected in [`sensor_msgs/JointState`](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/JointState.html), cementing this setup in place.
-This design is proposing to break with this practice and provide a message that can accommodate reported readings for an arbitrary set of joints and joint interfaces.
+This design is proposing to break with this practice and provide a message that can accommodate reported readings for an arbitrary set of joints or hardware interfaces.
 The proposed setup should both allow for reporting values for user-defined interfaces as well as making reporting position, velocity and effort optional.
 The rationale behind the latter is that it is currently left entirely to user-policy whether e.g. velocity and effort should be filled with zeroes when only position is reported and how to tell if this is the case.
-A set of mixed-type joints would e.g. have zeroes or NaNs for one joint in the position vector and effort but only fill velocity with proper values.
-
-Further in this text `value-type` is used to refer to a type of value reported in joint states, e.g. position, velocity and effort.
-
-Assumptions in the current setup:
-* the values in `position`, `velocity` and `effort` are aligned with the joint names in `name`.
+The flexible joint state message shall encompass a complex  hardware setup, covering a mix of different actuators and sensors.
+A set of mixed-type joints would e.g. be a mobile actuator.
+One could think of a diff drive controller only providing velocity values, whereas the manipulator provides the full joint state (`position`, `velocity`, `effort`) for its joints.
+In the example given, it would be possible to provide pre-defined fields in a statically defined joint state message, however this brings two problems with it:
+1. How can the user indicate that a certain field (e.g. `effort`) is not provided for the joint?
+Setting the value to a specific defined value such as `NaN` brings problems, latest when trying to serialize that message.
+2. What if neither of the provided fields are reported by the hardware?
+One example could be a suction gripper, which may report only the applied pressure or vacuum level, in which case it's again up to the user's creativity to violate one of the existing fields.
 
 ## Goal
 
+With the given motivation, We therefore propose to introduce a flexible way of providing custom values in the joint state message to address the given problems mentioned above.
+
+Further in this text `value-identifier` is used to refer to a type of value reported in joint states, e.g. `position`, `velocity` and `effort`.
+
 To define a new message that
-1. allows to report additional values on top of position, velocity and effort,
-2. does not enforce defining position, velocity and effort for every joint,
-3. does not enforce defining values for every joint in every value-type,
+1. does not enforce defining position, velocity and effort for every joint,
+1. supports different hardware interface to report additional values on top of position, velocity and effort,
+3. does not enforce defining values for every joint in every value-identifier,
 4. provides a realtime-friendly way of use (some assumptions are fair to use),
 
 ## Design
 
 The main advantage of `sensor_msgs/JointState` is that it provides a fairly flat structure which, given some assumptions are met, it is easy to process in realtime-safe code.
+Obviously, with the associate array it is easy to look up joint values for a name as its indices are aligned, i.e. the values in `position`, `velocity` and `effort` are aligned with the joint names in `name`.
 
 ```
 Header header
@@ -36,31 +43,78 @@ float64[] velocity
 float64[] effort
 ```
 
-### First proposal
+The following proposal reflects a map-like (similar to what `std::unordered_map` represents in C++ or a hash table in other languages) datatype where not only three statically chosen value-identifier are attached to a joint name, but can be set dynamically.
+
+### Proposal for a Dynamic Joint State Message
 
 ```
 Header header
 
-string[] name
+string[] interface_name
 InterfaceValue[] interface_value
-  string interface_name
+  string[] value_identifier
   float64[] value
 ```
 
-where `name` stands for a list of joint names, `interface_value` is a vector of a new message, holding the name of the interface and a list of values.
-Assumptions:
-* `interface_name` needs to be kept standard somehow
-* the values in `value` are aligned with the joint names in `name`.
+where `name` stands for a list of joint or hardware interface names, `interface_value` is a vector of a new message, being essentially a key-value pair, e.g. `effort` and `1.0`.
 
-Possible improvements:
-* Turn `interface_name` into an enum and define it in a message.
-This would be problematic as we are - yet again - baking names into the system.
-Extending the list would result in MD5 changes in this message too.
-* Support a set of helper functions in the form of header-only files along with `control_msgs`.
+In the example of the mobile manipulator, a possible configuration would look like the following:
+
+```
+Header header
+
+interface_name = ['wheel_left', 'wheel_right', 'joint_1', 'joint_2', …, 'joint_N', 'gripper_1']
+InterfaceValue = [wheel_left_iv, wheel_right_iv, joint_1_iv, joint_2_iv, …, joint_n_iv, gripper_1_iv]
+```
+where the `InterfaceValue` messages can be composed individually per `InterfaceName`.
+The name is similar to the already existing joint state message coming from the URDF.
+
+The `InterfaceValue` for the left wheel `wheel_left_iv` could be composed as such, reporting only its velocity:
+```
+value_identifier = ['velocity']
+value = [1.5]
+```
+
+The `InterfaceValue` for the first joint `joint_1_iv` reports a more complete interface:
+```
+value_identifier = ['position', 'velocity', 'effort']
+value = [1.1, 2.2, 3.3]
+```
+
+Additionally, the `InterfaceValue` for the gripper can be completely custom:
+```
+value_identifier = ['vaccuum_level', 'voltage']
+value = [4.4, 5.5]
+```
+
+That allows a relatively straight forward lookup of dynamically attached values per interface name.
+Each individual field is thus indexable by a tuple of `interface_name` and `value_identifier`.
+
+## Issues Considered
+
+### Name Lookup
+
+With a dynamically allocated message values, the value identifier might not comply to any standard.
+Imagine a torque controller working with a particular hardware setup (and thus a particular joint state message configuration).
+This controller needs to know whether it can compute a torque value based on `position`, `velocity` or something completely different.
+An additional drawback of this key-value pair is that the keys are not necessarily defined correctly.
+It can potentially be very cumbersome to debug the difference between a keys like `position`, or `pos`, or `pos_val`.
+
+*possible improvements:*
+A potential solution to this is to provide constants of the most applicable keys and use as such.
+Secondly, in order to pre-process whether all key-values pairs are available before, we propose a change to the controller interface to provide the used keys during startup time.
+This would allow to perform a sanity check before actually running the controller and potentially crash.
+For more details on this, we refer to the [Execution Management Desin Doc](controller_execution_management.md).
+Additionally, we could provide a set of helper functions in the form of header-only files along with `control_msgs`.
 Nothing says that a messages package cannot ship some util code, too.
 
-### Second proposal
+### Read Only Access
 
+// TODO, explain that with controller chaining, the resource management has to be addressed that values should be declared read-only
+
+## Discarded Designs
+
+### Matrix configuration
 ```
 Header header
 

--- a/design_drafts/flexible_joint_states_msg.md
+++ b/design_drafts/flexible_joint_states_msg.md
@@ -19,25 +19,25 @@ One example could be a suction gripper, which may report only the applied pressu
 
 ## Goal
 
-With the given motivation, we therefore propose to introduce a flexible way of providing custom values in the joint state message to address the given problems mentioned above.
+With the given motivation, we therefore propose to introduce a flexible way of reporting values in the joint state message to address the given problems mentioned above.
 
 Further in this text `value-identifier` is used to refer to a type of value reported in joint states, e.g. `position`, `velocity` and `effort`.
 
 The requirements for a flexible joint state message are fulfilled, if it
 1. does not enforce defining position, velocity and effort for every joint,
-1. supports different hardware interface to report additional values on top of position, velocity and effort,
+2. supports different hardware interface(s) additionally to position, velocity and effort,
 3. does not enforce defining values for every joint in every value-identifier,
 4. provides a realtime-friendly way of use (some assumptions are fair to use),
 
 If the requirements are all fulfilled, the flexible joint state message can replace the currently used `JointStateHandles`.
 One can consider the flexible joint state message to represent not only a ROS message, which being used for communication.
-The same message instance can be used internal to ROS control as a storage instance which is used to propagate the robot's state to the loaded controllers.
+The same message type can be used internally in `ros_control` as a storage instance which is used to propagate the robot's state to the loaded controllers and to convey desired joint/actuator commands to the robot hardware.
 That is, the hardware interface can fill the joint state message with all information the underlying hardware reports.
 This would traditionally be joint states such as `position` and `velocity`, but also provides the flexibility to be extended by non-classical hardware interfaces such as grippers or custom sensors/actuators.
 The joint state message would then be passed to each individual controller to read the appropriate information about of the message and perform their calculation.
-The result of each controller can be similarly be stored in the same instance of the joint state message which will be eventually passed back to the hardware interface.
+The result of each controller can similarly be stored in the same instance of the joint state message which will be eventually passed back to the hardware interface.
 The hardware interface then can extract the result of the controller's computation from the message and apply their values to the hardware.
-That not only allows to easily combine multiple controllers, but also a dynamic composition of the hardware interface to contain multiple interfaces to various hardware components such as robots, external grippers.
+That not only allows to easily combine multiple controllers, but also a dynamic composition of the hardware interfaces to contain multiple interfaces to various hardware components such as robots with interchangeable grippers.
 This composition can become extremely handy when dealing with external components to a robot, such as a gripper or the previously mentioned mobile manipulator, where the base platform is not necessarily coupled with the robotic arm.
 
 For more details on how the flexible joint state message can be used to create complex controller schemes, please refer to [controller execution management](controller_execution_management.md).
@@ -56,9 +56,9 @@ float64[] velocity
 float64[] effort
 ```
 
-The following proposal reflects a map-like (similar to what `std::unordered_map` represents in C++ or a hash table in other languages) datatype where not only three statically chosen value-identifier are attached to a joint name, but can be set dynamically.
+The following proposal reflects a map-like (similar to what `std::unordered_map` represents in C++ or a hash table in other languages) datatype where not only three statically chosen value-identifiers are attached to a joint name, but can be set dynamically.
 
-### Proposal for a Dynamic Joint State Message
+### Proposal for a Flexible Joint State Message
 
 ```
 Header header


### PR DESCRIPTION
Follow up PR extending the scope of the flexible joint state messages as well as providing more details for potential implementations as well as edge-cases.

* Applied style changes (one sentence per line)
* Declare the first proposal as the proposal to be implemented, introduce "discarded proposal" section.
* Add a bit more motivation and goal definition on how the flexible joint state message can replace the joint handles and a strict hardware interface
* Section about Access Control

Signed-off-by: Karsten Knese <karsten@openrobotics.org>