### PR TITLE
Add configuration for reviewer lottery

### DIFF
--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -1,0 +1,41 @@
+groups:
+  # Default reviewers for all pull requests.
+  # Usually, at least on of the maintainers should approve PR before merging.
+  # The best is if two maintainers do that.
+  - name: maintainers # name of the group
+    reviewers: 2 # how many reviewers do you want to assign?
+    internal_reviewers: 1 # how many reviewers do you want to assign when the PR author belongs to this group?
+    usernames: # github usernames of the reviewers
+      - bmagyar
+      - destogl
+
+  # Reviewers group to get broader feedback.
+  - name: reviewers
+    reviewers: 10
+    usernames:
+      - rosterloh
+      - kellyprankin
+      - progtologist
+      - arne48
+      - DasRoteSkelett
+      - a10263790
+      - Serafadam
+      - harderthan
+      - jaron-l
+      - malapatiravi
+      - erickisos
+      - ShawnSchaerer
+      - Briancbn
+      - TomoyaFujita2016
+      - homalozoa
+      - anfemosa
+      - jackcenter
+      - VX792
+      - mhubii
+      - livanov93
+      - aprotyas
+      - peterdavidfagan
+      - UsamaHamayun1
+      - duringhof
+      - bijoua29
+      - kasiceo

--- a/.github/workflows/reviewer-lottery.yml
+++ b/.github/workflows/reviewer-lottery.yml
@@ -1,0 +1,13 @@
+name: Reviewer lottery
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: uesteibar/reviewer-lottery@v2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Copied from ros2_control repo

The difference is that I propose to have **10** reviews per design proposal. Here is important to reach broad range of users.